### PR TITLE
Fix build on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ keywords = ["file", "watcher", "command-line", "trigger"]
 license = "Apache-2.0"
 
 [dependencies]
-clap = "~2.19.0"
+clap = "~2.21.0"
 humantime = "~1.0.0"
 notify = "~3.0.0"


### PR DESCRIPTION
Hi.

https://github.com/rust-lang/rust/pull/42894 makes some compatibility lints in `rustc` deny-by-default and regression testing found that this crate is affected through an outdated version of `clap`. Here's a patch slightly bumping the `clap` version and fixing the issue (see https://github.com/rust-lang/rust/issues/40107 for more information about the issue).